### PR TITLE
fixes(signature) Escape 3 characters used by base64 = / +

### DIFF
--- a/src/main/java/com/mendix/cloud/urlsign/URLSigner.java
+++ b/src/main/java/com/mendix/cloud/urlsign/URLSigner.java
@@ -2,6 +2,7 @@ package com.mendix.cloud.urlsign;
 
 import com.mendix.cloud.urlsign.exception.KeyImporterException;
 import com.mendix.cloud.urlsign.exception.URLSignerException;
+import com.mendix.cloud.urlsign.util.URLUtils;
 import org.apache.http.client.utils.URIBuilder;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
@@ -60,7 +61,8 @@ public class URLSigner {
             String uriToSign = uriBuilder.build().toASCIIString();
             byte[] signature = getSignature(uriToSign.getBytes(StandardCharsets.UTF_8.name()));
             String signatureValue = DatatypeConverter.printBase64Binary(signature);
-            uriBuilder.addParameter(URL_SIGNATURE, signatureValue);
+            String signatureValueEscaped = URLUtils.escapeBase64String(signatureValue);
+            uriBuilder.addParameter(URL_SIGNATURE, signatureValueEscaped);
             return uriBuilder.build();
         } catch (Exception e) {
             throw new URLSignerException(e);

--- a/src/main/java/com/mendix/cloud/urlsign/URLVerifier.java
+++ b/src/main/java/com/mendix/cloud/urlsign/URLVerifier.java
@@ -13,7 +13,8 @@ import javax.xml.bind.DatatypeConverter;
 import java.io.File;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import java.security.*;
+import java.security.PublicKey;
+import java.security.Signature;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
@@ -102,7 +103,9 @@ public class URLVerifier {
             uriBuilder.setParameters(queryParams);
 
             String uriToVerify = uriBuilder.build().toASCIIString();
-            byte[] signature = DatatypeConverter.parseBase64Binary(signatureNameValuePair.getValue());
+
+            String unescapedSignatureValue = URLUtils.unescapeBase64String(signatureNameValuePair.getValue());
+            byte[] signature = DatatypeConverter.parseBase64Binary(unescapedSignatureValue);
             return getVerification(uriToVerify.getBytes(StandardCharsets.UTF_8.name()), signature);
         } catch (Exception e) {
             throw new URLVerifierException(e);

--- a/src/main/java/com/mendix/cloud/urlsign/util/URLUtils.java
+++ b/src/main/java/com/mendix/cloud/urlsign/util/URLUtils.java
@@ -8,6 +8,9 @@ import java.nio.charset.StandardCharsets;
 
 public class URLUtils {
 
+    final static char[] chars1 = {'+', '=', '/'};
+    final static char[] chars2 = {'~', '-', '_'};
+
     public static String getFullURL(HttpServletRequest request) throws URLVerifierException {
         StringBuffer requestURL = request.getRequestURL();
         String queryString = request.getQueryString();
@@ -24,5 +27,25 @@ public class URLUtils {
         } catch (Exception e) {
             throw new URLVerifierException(e);
         }
+    }
+
+    public static String escapeBase64String(String str) {
+        assert chars1.length == chars2.length;
+
+        String escapedString = new String(str);
+        for (int i = 0; i < chars1.length; i++) {
+            escapedString = escapedString.replace(chars1[i], chars2[i]);
+        }
+        return escapedString;
+    }
+
+    public static String unescapeBase64String(String str) {
+        assert chars1.length == chars2.length;
+
+        String unescapedString = new String(str);
+        for (int i = 0; i < chars1.length; i++) {
+            unescapedString = unescapedString.replace(chars2[i], chars1[i]);
+        }
+        return unescapedString;
     }
 }


### PR DESCRIPTION
```
See http://stackoverflow.com/questions/1374753/passing-base64-encoded-strings-in-url
```

Spend too many hours trying to get it right. But it seems like an impossible task with URIBuilder and its friends doing magic. This solution may not be the prettiest but it works with base64.
