### PR TITLE
Use X-Forwarded-Scheme if present. If not X-Forwarded-Proto

### DIFF
--- a/src/main/java/com/mendix/cloud/urlsign/util/URLUtils.java
+++ b/src/main/java/com/mendix/cloud/urlsign/util/URLUtils.java
@@ -26,16 +26,27 @@ public class URLUtils {
             fullUrl = requestURL.append('?').append(queryString).toString();
         }
 
-        String forwardedProtocol = request.getHeader("X-Forwarded-Proto");
-        if (forwardedProtocol != null) {
-            fullUrl = fullUrl.replaceFirst("http://", forwardedProtocol + "://");
-        }
+        fullUrl = replaceURLSchemeIfNeeded(request, fullUrl);
 
         try {
             return URLDecoder.decode(fullUrl, StandardCharsets.UTF_8.name());
         } catch (UnsupportedEncodingException e) {
             throw new URLSignException("Error while decoding full URL.", e);
         }
+    }
+
+    public static String replaceURLSchemeIfNeeded(HttpServletRequest request, String url) {
+        String forwardedScheme = request.getHeader("X-Forwarded-Scheme");
+        String forwardedProto = request.getHeader("X-Forwarded-Proto");
+
+        String scheme = forwardedProto;
+        if (forwardedScheme != null)
+            scheme = forwardedScheme;
+
+        if (scheme != null) {
+            return url.replaceFirst("http://", scheme + "://");
+        }
+        return url;
     }
 
     public static String escapeBase64String(String str) {


### PR DESCRIPTION
CF deployed app have the following headers:
- X-Forwarded-Scheme: https
- X-Forwarded-Proto: tcp

AWS ELB deployed app (e.g. deployer) have the following headers:
- X-Forwarded-Scheme: _not-set_
- X-Forwarded-Proto: https

This change gives `X-Forwarded-Scheme` more priority over `X-Forwarded-Proto`
